### PR TITLE
Fix transaction creation by adding Content-Type on PUT/POST requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -135,6 +135,9 @@ func (c *client) do(method, url string, responseModel interface{}, requestBody [
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
+	if method == http.MethodPost || method == http.MethodPut {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	res, err := c.client.Do(req)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -209,6 +209,31 @@ func TestClient_POST(t *testing.T) {
 			Foo string `json:"foo"`
 		}{}, response)
 	})
+
+	t.Run("regression test existence of request header content-type = application/json", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodPost, fmt.Sprintf("%s%s", apiEndpoint, "/foo"),
+			func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
+				res := httpmock.NewStringResponse(http.StatusOK, `{"bar":"foo"}`)
+				res.Header.Add("X-Rate-Limit", "36/200")
+				return res, nil
+			},
+		)
+
+		response := struct {
+			Foo string `json:"foo"`
+		}{}
+
+		c := NewClient("")
+		err := c.(*client).POST("/foo", &response, []byte(`{"bar":"foo"}`))
+		assert.NoError(t, err)
+		assert.Equal(t, struct {
+			Foo string `json:"foo"`
+		}{}, response)
+	})
 }
 
 func TestClient_PUT(t *testing.T) {
@@ -294,6 +319,31 @@ func TestClient_PUT(t *testing.T) {
 
 		httpmock.RegisterResponder(http.MethodPut, fmt.Sprintf("%s%s", apiEndpoint, "/foo"),
 			func(req *http.Request) (*http.Response, error) {
+				res := httpmock.NewStringResponse(http.StatusOK, `{"bar":"foo"}`)
+				res.Header.Add("X-Rate-Limit", "36/200")
+				return res, nil
+			},
+		)
+
+		response := struct {
+			Foo string `json:"foo"`
+		}{}
+
+		c := NewClient("")
+		err := c.(*client).PUT("/foo", &response, []byte(`{"bar":"foo"}`))
+		assert.NoError(t, err)
+		assert.Equal(t, struct {
+			Foo string `json:"foo"`
+		}{}, response)
+	})
+
+	t.Run("regression test existence of request header content-type = application/json", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodPut, fmt.Sprintf("%s%s", apiEndpoint, "/foo"),
+			func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
 				res := httpmock.NewStringResponse(http.StatusOK, `{"bar":"foo"}`)
 				res.Header.Add("X-Rate-Limit", "36/200")
 				return res, nil


### PR DESCRIPTION
Closes https://github.com/brunomvsouza/ynab.go/issues/5

Mea culpa :) Thank you @askielboe for finding the issue and for the through report (https://github.com/brunomvsouza/ynab.go/issues/5) you created. It helped to solve this quickly.

All API's `PUT` and `POST` requests need to be sent with `Content-Type: application/json`. 

- Add the fix 
- Add regression tests so it doesn't happen again

After the CI run I'll create a new release so ppl can use.

Code below should behave as expected after this PR is merged.
```go
func ExampleClientServicer_Transaction_fix() {
	c := ynab.NewClient("<API-TOKEN>")

	bucketID := "<BUCKET-ID>"
	transactionDate, err := api.DateFromString("2018-01-01")
	transactions := []transaction.PayloadTransaction{
		{
			AccountID: "<ACCOUNT-ID>",
			Date:      transactionDate,
			Amount:    int64(-10000),
			Cleared:   transaction.ClearingStatusUncleared,
			Approved:  true,
		},
		{
			AccountID: "<ACCOUNT-ID>",
			Date:      transactionDate,
			Amount:    int64(-10000),
			Cleared:   transaction.ClearingStatusUncleared,
			Approved:  true,
		},
	}

	r, err := c.Transaction().BulkCreateTransactions(bucketID, transactions)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("%#v\n", r)
}

func ExampleClientServicer_Transaction_fix2() {
	c := ynab.NewClient("<API-TOKEN>")

	bucketID := "<BUCKET-ID>"
	transactionDate, err := api.DateFromString("2018-01-01")
	if err != nil {
		log.Fatal(err)
	}

	tt := transaction.PayloadTransaction{
		AccountID: "<ACCOUNT-ID>",
		Date:      transactionDate,
		Amount:    int64(-10000),
		Cleared:   transaction.ClearingStatusUncleared,
		Approved:  true,
	}

	r, err := c.Transaction().CreateTransaction(bucketID, tt)
	if err != nil {
		log.Println(err)
	}

	fmt.Printf("%#v\n", r)
}
```