### PR TITLE
goal_percentage_complete can be greater than 100 percent

### DIFF
--- a/api/category/entity.go
+++ b/api/category/entity.go
@@ -30,7 +30,7 @@ type Category struct {
 	// this is the target month for the goal to be completed
 	GoalTargetMonth *api.Date `json:"goal_target_month"`
 	// GoalPercentageComplete the percentage completion of the goal
-	GoalPercentageComplete *uint8 `json:"goal_percentage_complete"`
+	GoalPercentageComplete *uint16 `json:"goal_percentage_complete"`
 }
 
 // Group represents a resumed category group for a budget

--- a/api/category/service_test.go
+++ b/api/category/service_test.go
@@ -61,8 +61,8 @@ func TestService_GetCategories(t *testing.T) {
 	assert.NoError(t, err)
 
 	var (
-		expectedGoalTarget             int64 = 18740
-		expectedGoalPercentageComplete uint8 = 20
+		expectedGoalTarget             int64  = 18740
+		expectedGoalPercentageComplete uint16 = 20
 	)
 	expectedGoalCreationMonth, err := api.DateFromString("2018-04-01")
 	assert.NoError(t, err)
@@ -138,8 +138,8 @@ func TestService_GetCategory(t *testing.T) {
 	assert.NoError(t, err)
 
 	var (
-		expectedGoalTarget             int64 = 18740
-		expectedGoalPercentageComplete uint8 = 20
+		expectedGoalTarget             int64  = 18740
+		expectedGoalPercentageComplete uint16 = 20
 	)
 	expectedGoalCreationMonth, err := api.DateFromString("2018-04-01")
 	assert.NoError(t, err)


### PR DESCRIPTION
I have a category that returned 1072 percent complete, this won't fit into unit8.

context: unplanned expense that had to be funded, which pushed it way over the monthly goal.
