### PR TITLE
fix golint warning

### DIFF
--- a/client.go
+++ b/client.go
@@ -185,9 +185,5 @@ func (c *client) do(method, url string, responseModel interface{}, requestBody [
 	c.rateLimit = rl
 	c.Unlock()
 
-	if err := json.Unmarshal(body, &responseModel); err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(body, &responseModel)
 }


### PR DESCRIPTION
See https://goreportcard.com/report/github.com/brunomvsouza/ynab.go#golint

warning: redundant if ...; err != nil check, just return error instead. (golint)