### PR TITLE
Deprecating bulk transactions endpoint

### DIFF
--- a/api/transaction/entity.go
+++ b/api/transaction/entity.go
@@ -194,3 +194,17 @@ type Bulk struct {
 	// specified import IDs will be included in this list
 	DuplicateImportIDs []string `json:"duplicate_import_ids"`
 }
+
+// CreatedTransactions represents the output of transactions being created
+type CreatedTransactions struct {
+	// TransactionIDs The list of Transaction IDs that were created
+	TransactionIDs []string `json:"transaction_ids"`
+	// DuplicateImportIDs If any Transactions were not created because they had an
+	// import ID matching a transaction already on the same account, the
+	// specified import IDs will be included in this list
+	DuplicateImportIDs []string `json:"duplicate_import_ids"`
+	// Transactions If multiple transactions were specified, the transactions that were saved
+	Transactions []*Transaction `json:"transactions"`
+	// Transactions If a single transaction was specified, the transaction that was saved
+	Transaction *Transaction `json:"transaction"`
+}

--- a/api/transaction/entity.go
+++ b/api/transaction/entity.go
@@ -185,6 +185,7 @@ type ScheduledSubTransaction struct {
 }
 
 // Bulk represents the output of transactions being created in bulk mode
+// Deprecated: Use BulkTransactions instead.
 type Bulk struct {
 	// TransactionIDs The list of Transaction IDs that were created
 	TransactionIDs []string `json:"transaction_ids"`

--- a/api/transaction/example_test.go
+++ b/api/transaction/example_test.go
@@ -22,7 +22,21 @@ func ExampleService_CreateTransaction() {
 	tx, _ := c.Transaction().CreateTransaction("<valid_budget_id>", p)
 	fmt.Println(reflect.TypeOf(tx))
 
-	// Output: *transaction.Transaction
+	// Output: *transaction.CreatedTransactions
+}
+
+func ExampleService_CreateTransactions() {
+	c := ynab.NewClient("<valid_ynab_access_token>")
+	p := []transaction.PayloadTransaction{
+		{
+			AccountID: "<valid_account_id>",
+			// ...
+		},
+	}
+	tx, _ := c.Transaction().CreateTransactions("<valid_budget_id>", p)
+	fmt.Println(reflect.TypeOf(tx))
+
+	// Output: *transaction.CreatedTransactions
 }
 
 func ExampleService_BulkCreateTransactions() {

--- a/api/transaction/service.go
+++ b/api/transaction/service.go
@@ -63,12 +63,20 @@ func (s *Service) GetTransaction(budgetID, transactionID string) (*Transaction, 
 // CreateTransaction creates a new transaction for a budget
 // https://api.youneedabudget.com/v1#/Transactions/createTransaction
 func (s *Service) CreateTransaction(budgetID string,
-	p PayloadTransaction) (*Transaction, error) {
+	p PayloadTransaction) (*CreatedTransactions, error) {
+
+	return s.CreateTransactions(budgetID, []PayloadTransaction{p})
+}
+
+// CreateTransactions creates one or more new transactions for a budget
+// https://api.youneedabudget.com/v1#/Transactions/createTransaction
+func (s *Service) CreateTransactions(budgetID string,
+	p []PayloadTransaction) (*CreatedTransactions, error) {
 
 	payload := struct {
-		Transaction *PayloadTransaction `json:"transaction"`
+		Transactions []PayloadTransaction `json:"transactions"`
 	}{
-		&p,
+		p,
 	}
 
 	buf, err := json.Marshal(&payload)
@@ -77,16 +85,15 @@ func (s *Service) CreateTransaction(budgetID string,
 	}
 
 	resModel := struct {
-		Data struct {
-			Transaction *Transaction `json:"transaction"`
-		} `json:"data"`
+		Data *CreatedTransactions `json:"data"`
 	}{}
 
 	url := fmt.Sprintf("/budgets/%s/transactions", budgetID)
-	if err := s.c.POST(url, &resModel, buf); err != nil {
+	err = s.c.POST(url, &resModel, buf)
+	if err != nil {
 		return nil, err
 	}
-	return resModel.Data.Transaction, nil
+	return resModel.Data, nil
 }
 
 // BulkCreateTransactions creates multiple transactions for a budget

--- a/api/transaction/service.go
+++ b/api/transaction/service.go
@@ -91,6 +91,7 @@ func (s *Service) CreateTransaction(budgetID string,
 
 // BulkCreateTransactions creates multiple transactions for a budget
 // https://api.youneedabudget.com/v1#/Transactions/bulkCreateTransactions
+// Deprecated: Use transaction.CreateTransactions instead.
 func (s *Service) BulkCreateTransactions(budgetID string,
 	ps []PayloadTransaction) (*Bulk, error) {
 


### PR DESCRIPTION
"We’ve soft-deprecated POST /budgets/{budget_id}/transactions/bulk. 
It still works and we still support it, but 
POST /budgets/{budget_id}/transactions with a transactions array is 
likely the more future-proof way of creating multiple transactions."

Source: https://www.youneedabudget.com/release-notes/