### PR TITLE
Support ID in TransactionPayload

### DIFF
--- a/api/transaction/payload.go
+++ b/api/transaction/payload.go
@@ -10,6 +10,7 @@ import (
 
 // PayloadTransaction is the payload contract for saving a transaction, new or existent
 type PayloadTransaction struct {
+	ID        string   `json:"id"`
 	AccountID string   `json:"account_id"`
 	Date      api.Date `json:"date"`
 	// Amount The transaction amount in milliunits format

--- a/api/transaction/service_test.go
+++ b/api/transaction/service_test.go
@@ -877,6 +877,7 @@ func TestService_UpdateTransactions(t *testing.T) {
 
 	payload := []transaction.PayloadTransaction{
 		{
+			ID:         "0f5b3f73-ded2-4dd7-8b01-c23022622cd6",
 			AccountID:  "09eaca5e-312a-4bcd-89c4-828fb90638f2",
 			Date:       payloadDate,
 			Amount:     int64(-9000),
@@ -889,6 +890,7 @@ func TestService_UpdateTransactions(t *testing.T) {
 			FlagColor:  &payloadFlagColor,
 		},
 		{
+			ID:         "0f5b3f73-ded2-4dd7-8b01-c23022622cd7",
 			AccountID:  "09eaca5e-312a-4bcd-89c4-828fb90638f2",
 			Date:       payloadDate,
 			Amount:     int64(-2000),


### PR DESCRIPTION
Support of `ID` field in the `TransactionPayload` struct. Needed for `UpdateTransactions()` method. Official YNAB doc: https://api.youneedabudget.com/v1#/Transactions/updateTransactions