### PR TITLE
Make TransferPayeeID field available in Account type

### DIFF
--- a/api/account/entity.go
+++ b/api/account/entity.go
@@ -22,6 +22,9 @@ type Account struct {
 	Deleted bool `json:"deleted"`
 
 	Note *string `json:"note"`
+	
+	// TransferPayeeID The payee ID that can be used when creating transfer transactions
+	TransferPayeeID string `json:"transfer_payee_id"`
 }
 
 // SearchResultSnapshot represents a versioned snapshot for an account search


### PR DESCRIPTION
In order to implement money  transfer transactions between accounts, the transfer_payee_id field from the account must be accessible within the Account struct