### PR TITLE
Add DeleteTransaction API call

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -16,6 +16,7 @@ type ClientWriter interface {
 	POST(url string, responseModel interface{}, requestBody []byte) error
 	PUT(url string, responseModel interface{}, requestBody []byte) error
 	PATCH(url string, responseModel interface{}, requestBody []byte) error
+	DELETE(url string, responseModel interface{}) error
 }
 
 // ClientReaderWriter contract for a read-write client

--- a/api/transaction/service.go
+++ b/api/transaction/service.go
@@ -183,6 +183,23 @@ func (s *Service) UpdateTransactions(budgetID string,
 	return resModel.Data, nil
 }
 
+// DeleteTransaction deletes a transaction from a budget
+// https://api.youneedabudget.com/v1#/Transactions/deleteTransaction
+func (s *Service) DeleteTransaction(budgetID, transactionID string) (*Transaction, error) {
+	resModel := struct {
+		Data struct {
+			Transaction *Transaction `json:"transaction"`
+		} `json:"data"`
+	}{}
+
+	url := fmt.Sprintf("/budgets/%s/transactions/%s", budgetID, transactionID)
+	err := s.c.DELETE(url, &resModel)
+	if err != nil {
+		return nil, err
+	}
+	return resModel.Data.Transaction, nil
+}
+
 // GetTransactionsByAccount fetches the list of transactions of a specific account
 // from a budget with filtering capabilities
 // https://api.youneedabudget.com/v1#/Transactions/getTransactionsByAccount
@@ -257,7 +274,7 @@ func (s *Service) GetTransactionsByPayee(budgetID, payeeID string,
 
 // GetScheduledTransactions fetches the list of scheduled transactions from
 // a budget
-//https://api.youneedabudget.com/v1#/Scheduled_Transactions/getScheduledTransactions
+// https://api.youneedabudget.com/v1#/Scheduled_Transactions/getScheduledTransactions
 func (s *Service) GetScheduledTransactions(budgetID string) ([]*Scheduled, error) {
 	resModel := struct {
 		Data struct {

--- a/api/transaction/service_test.go
+++ b/api/transaction/service_test.go
@@ -1190,6 +1190,39 @@ func TestService_UpdateTransaction(t *testing.T) {
 	assert.Equal(t, expectedTransaction, tx)
 }
 
+func TestService_DeleteTransaction(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	url := "https://api.youneedabudget.com/v1/budgets/aa248caa-eed7-4575-a990-717386438d2c/transactions/e6ad88f5-6f16-4480-9515-5377012750dd"
+	httpmock.RegisterResponder(http.MethodDelete, url,
+		func(req *http.Request) (*http.Response, error) {
+			res := httpmock.NewStringResponse(200, `{
+  "data": {
+    "transaction": {
+			"id": "e6ad88f5-6f16-4480-9515-5377012750dd"
+		}
+	}
+}
+		`)
+			res.Header.Add("X-Rate-Limit", "36/200")
+			return res, nil
+		},
+	)
+
+	client := ynab.NewClient("")
+	tx, err := client.Transaction().DeleteTransaction(
+		"aa248caa-eed7-4575-a990-717386438d2c",
+		"e6ad88f5-6f16-4480-9515-5377012750dd",
+	)
+	assert.NoError(t, err)
+
+	expected := &transaction.Transaction{
+		ID: "e6ad88f5-6f16-4480-9515-5377012750dd",
+	}
+	assert.Equal(t, expected, tx)
+}
+
 func TestFilter_ToQuery(t *testing.T) {
 	sinceDate, err := api.DateFromString("2020-02-02")
 	assert.NoError(t, err)

--- a/client.go
+++ b/client.go
@@ -135,6 +135,11 @@ func (c *client) PATCH(url string, responseModel interface{}, requestBody []byte
 	return c.do(http.MethodPatch, url, responseModel, requestBody)
 }
 
+// DELETE sends a DELETE request to the YNAB API
+func (c *client) DELETE(url string, responseModel interface{}) error {
+	return c.do(http.MethodDelete, url, responseModel, nil)
+}
+
 // do sends a request to the YNAB API
 func (c *client) do(method, url string, responseModel interface{}, requestBody []byte) error {
 	fullURL := fmt.Sprintf("%s%s", apiEndpoint, url)


### PR DESCRIPTION
This adds functionality for the delete transaction API call.

TBH, I'm a little unclear on the value of some of these tests, but I tried to do them in line with what already exists.