### PR TITLE
Breaking API change fix: don't try to parse X-Rate-Limit if it doesn't exist

### DIFF
--- a/client.go
+++ b/client.go
@@ -181,14 +181,16 @@ func (c *client) do(method, url string, responseModel interface{}, requestBody [
 		return response.Error
 	}
 
-	rl, err := api.ParseRateLimit(res.Header.Get("X-Rate-Limit"))
-	if err != nil {
-		return err
+	rlHeader := res.Header.Get("X-Rate-Limit")
+	if len(rlHeader) > 0 {
+		rl, err := api.ParseRateLimit(rlHeader)
+		if err != nil {
+			return err
+		}
+		c.Lock()
+		c.rateLimit = rl
+		c.Unlock()
 	}
-
-	c.Lock()
-	c.rateLimit = rl
-	c.Unlock()
 
 	return json.Unmarshal(body, &responseModel)
 }


### PR DESCRIPTION
Hi there! Thanks for your work on this library, I've been using it for 18 months now.

YNAB seems to have made some changes to their rate limiting headers in [ynab api 1.73.0](https://api.ynab.com/#v1.73.0):
>When a 429 Too Many Requests response is returned because the Rate Limit has been exceeded, a X-Rate-Limit response header is no longer included.

I'm not sure if it was intended, but at least for the `GET /budgets` endpoint, the `X-Rate-Limit` response header is not being set. This is causing a failure of this library with message "api: invalid rate limit string". It's not clear to me from the changelog what the intended change was or why it would affect this request.

This PR parses the header only if it is set on the response.

I want to thank @adamkrieger for also finding this issue and fixing it in his fork at https://github.com/adamkrieger/ynab.go. Relevant commit: https://github.com/adamkrieger/ynab.go/commit/ab9d79f531ac16269dccfa2f0bb39bf87f8f25eb