### PR TITLE
fix: Use PATCH instead of PUT and correct request payload structure

### DIFF
--- a/api/category/service.go
+++ b/api/category/service.go
@@ -111,7 +111,7 @@ func (s *Service) updateCategoryForMonth(budgetID, categoryID, month string,
 	p PayloadMonthCategory) (*Category, error) {
 
 	payload := struct {
-		MonthCategory *PayloadMonthCategory `json:"month_category"`
+		MonthCategory *PayloadMonthCategory `json:"category"`
 	}{
 		&p,
 	}
@@ -130,7 +130,7 @@ func (s *Service) updateCategoryForMonth(budgetID, categoryID, month string,
 	url := fmt.Sprintf("/budgets/%s/months/%s/categories/%s", budgetID,
 		month, categoryID)
 
-	if err := s.c.PUT(url, &resModel, buf); err != nil {
+	if err := s.c.PATCH(url, &resModel, buf); err != nil {
 		return nil, err
 	}
 	return resModel.Data.Category, nil

--- a/api/category/service_test.go
+++ b/api/category/service_test.go
@@ -321,10 +321,10 @@ func TestService_UpdateCategoryForMonth(t *testing.T) {
 	}
 
 	url := "https://api.youneedabudget.com/v1/budgets/aa248caa-eed7-4575-a990-717386438d2c/months/0001-01-01/categories/13419c12-78d3-4a26-82ca-1cde7aa1d6f8"
-	httpmock.RegisterResponder(http.MethodPut, url,
+	httpmock.RegisterResponder(http.MethodPatch, url,
 		func(req *http.Request) (*http.Response, error) {
 			resModel := struct {
-				MonthCategory *category.PayloadMonthCategory `json:"month_category"`
+				MonthCategory *category.PayloadMonthCategory `json:"category"`
 			}{}
 			err := json.NewDecoder(req.Body).Decode(&resModel)
 			assert.NoError(t, err)
@@ -401,10 +401,10 @@ func TestService_UpdateCategoryForCurrentMonth(t *testing.T) {
 	}
 
 	url := "https://api.youneedabudget.com/v1/budgets/aa248caa-eed7-4575-a990-717386438d2c/months/current/categories/13419c12-78d3-4a26-82ca-1cde7aa1d6f8"
-	httpmock.RegisterResponder(http.MethodPut, url,
+	httpmock.RegisterResponder(http.MethodPatch, url,
 		func(req *http.Request) (*http.Response, error) {
 			resModel := struct {
-				MonthCategory *category.PayloadMonthCategory `json:"month_category"`
+				MonthCategory *category.PayloadMonthCategory `json:"category"`
 			}{}
 			err := json.NewDecoder(req.Body).Decode(&resModel)
 			assert.NoError(t, err)


### PR DESCRIPTION
- Changed HTTP method from PUT to PATCH for category updates
- Updated JSON payload to use "category" instead of "month_category"
- Fixed field naming from "Budgeted" to "budgeted"
- Ensured compliance with YNAB API specification

Closes #40