### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,4 +1,6 @@
 name: "Lint & Test"
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/brunovenceslau/ynab.go/security/code-scanning/1](https://github.com/brunovenceslau/ynab.go/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/build-and-test.yaml` at the workflow root (top-level, alongside `name` and `on`) so it applies to all jobs unless overridden. For this workflow, the minimal required scope is:

- `contents: read`

This preserves existing behavior (checkout, lint, test) while enforcing least privilege and satisfying CodeQL. No imports, methods, or additional definitions are needed—just YAML configuration in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
