### PR TITLE
feat: runnable examples in examples/ (v1.6.1)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,10 @@ jobs:
         if: matrix.go != '1.25.x'
         run: make apidiff
 
+      - name: make apidiff-selftest
+        if: matrix.go != '1.25.x'
+        run: make apidiff-selftest
+
       - name: make check-version-selftest
         if: matrix.go != '1.25.x'
         run: make check-version-selftest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,9 @@ jobs:
         if: matrix.go != '1.25.x'
         run: make lint
 
+      - name: make examples
+        run: make examples
+
       - name: make test
         run: make test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this module are documented here, in
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-07-21
+
+### Added
+
+- `examples/` directory with runnable programs, most of which call the live API —
+  quickstart, delta-sync (with a persisted cursor), split transactions,
+  and mock-based testing. Complements the offline godoc examples on
+  pkg.go.dev, which stay `httptest`-backed so they run and verify in CI.
+
 ## [1.6.0] - 2026-07-21
 
 Version numbering note: this is the first release of the rewrite, and
@@ -58,5 +67,6 @@ history for humans. (Under `pkg.venceslau.dev/ynab` the old versions
 are retracted: `@latest` and version ranges never pick them, though an
 explicit pin still resolves with a warning.)
 
-[Unreleased]: https://github.com/brunovenceslau/ynab.go/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/brunovenceslau/ynab.go/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/brunovenceslau/ynab.go/releases/tag/v1.6.1
 [1.6.0]: https://github.com/brunovenceslau/ynab.go/releases/tag/v1.6.0

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ACTIONLINT := CGO_ENABLED=0 go run github.com/rhysd/actionlint/cmd/actionlint@$(
 GORELEASE := CGO_ENABLED=0 go run golang.org/x/exp/cmd/gorelease@$(XEXP_VERSION)
 
 .PHONY: test vet lint contract coverage update-spec smoke integration vulncheck tidy-check actionlint \
-	check-version-selftest local-ci go-latest-check apidiff
+	check-version-selftest local-ci go-latest-check apidiff examples
 
 test:
 	go test -race -shuffle=on ./...
@@ -22,14 +22,23 @@ vet:
 lint: vet
 	$(GOLANGCI_LINT) run
 
+# examples/ are real programs (hit the live API); CI compiles them but
+# never runs them (no token). Kept building so the docs cannot rot.
+# CGO_ENABLED=0: no cgo needed, and the host toolchain lacks it.
+examples:
+	CGO_ENABLED=0 go build ./examples/...
+
 contract:
 	go test -run 'TestContract' ./...
 
 # -coverpkg=./... merges cross-package coverage: without it, code covered
 # only from another package's tests (transport.DoRaw via root tests, e.g.)
 # reads 0% and the gate lies.
+# -coverpkg excludes examples/ — they are runnable main programs, not
+# library code, and would silently dilute the tracked coverage number.
 coverage:
-	go test -race -coverpkg=./... -coverprofile=cover.out ./... && go tool cover -func=cover.out
+	go test -race -coverpkg=$$(go list ./... | grep -v /examples/ | paste -sd,) \
+		-coverprofile=cover.out ./... && go tool cover -func=cover.out
 
 vulncheck:
 	$(GOVULNCHECK) ./...
@@ -86,7 +95,7 @@ apidiff:
 	fi
 
 # Everything the CI's full leg runs, locally — burn zero Actions minutes.
-local-ci: lint test contract vulncheck tidy-check actionlint check-version-selftest apidiff coverage
+local-ci: lint examples test contract vulncheck tidy-check actionlint check-version-selftest apidiff coverage
 
 # The toolchain twin of the spec-drift watch: fails when go.dev lists a
 # newer stable Go than the newest one pinned in the workflows, so the

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ XEXP_VERSION := v0.0.0-20260718201538-764159d718ef
 GOLANGCI_LINT := CGO_ENABLED=0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOVULNCHECK := CGO_ENABLED=0 go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
 ACTIONLINT := CGO_ENABLED=0 go run github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
-GORELEASE := CGO_ENABLED=0 go run golang.org/x/exp/cmd/gorelease@$(XEXP_VERSION)
+# GORELEASE_CMD is the pinned gorelease invocation without the cgo prefix, so
+# scripts/apidiff.sh can run it as an argv (a leading VAR=val is not an arg).
+GORELEASE_CMD := go run golang.org/x/exp/cmd/gorelease@$(XEXP_VERSION)
 
 .PHONY: test vet lint contract coverage update-spec smoke integration vulncheck tidy-check actionlint \
 	check-version-selftest local-ci go-latest-check apidiff examples
@@ -85,14 +87,11 @@ check-version-selftest:
 # and belongs to the archived predecessor's module path, so an implicit
 # base would produce a garbage cross-module diff). Before the first
 # family release the target says so and passes; after v1.6.0 it bites
-# on every run, against an explicit base.
+# on every run, against an explicit base. The gate exempts one symbol —
+# the Version constant, release metadata that changes every release — while
+# still failing on any other incompatible change; see scripts/apidiff.sh.
 apidiff:
-	@base=$$(git tag -l 'v1.[6-9]*' 'v1.[1-9][0-9]*' 'v[2-9]*' | sort -V | tail -1); \
-	if [ -z "$$base" ]; then \
-		echo 'apidiff: no released tag in this module family yet — activates after v1.6.0'; \
-	else \
-		$(GORELEASE) -base=$$base; \
-	fi
+	@CGO_ENABLED=0 scripts/apidiff.sh $(GORELEASE_CMD)
 
 # Everything the CI's full leg runs, locally — burn zero Actions minutes.
 local-ci: lint examples test contract vulncheck tidy-check actionlint check-version-selftest apidiff coverage

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ACTIONLINT := CGO_ENABLED=0 go run github.com/rhysd/actionlint/cmd/actionlint@$(
 GORELEASE_CMD := go run golang.org/x/exp/cmd/gorelease@$(XEXP_VERSION)
 
 .PHONY: test vet lint contract coverage update-spec smoke integration vulncheck tidy-check actionlint \
-	check-version-selftest local-ci go-latest-check apidiff examples
+	check-version-selftest local-ci go-latest-check apidiff apidiff-selftest examples
 
 test:
 	go test -race -shuffle=on ./...
@@ -93,8 +93,15 @@ check-version-selftest:
 apidiff:
 	@CGO_ENABLED=0 scripts/apidiff.sh $(GORELEASE_CMD)
 
+# The network-free proof that apidiff.sh's Version exemption is exact: it must
+# pass a Version value bump yet still fail every other break (removal, kind
+# change, a break in another package, a gorelease crash). Twin of
+# check-version-selftest; no real gorelease, no crafted API break.
+apidiff-selftest:
+	@scripts/apidiff-selftest.sh
+
 # Everything the CI's full leg runs, locally — burn zero Actions minutes.
-local-ci: lint examples test contract vulncheck tidy-check actionlint check-version-selftest apidiff coverage
+local-ci: lint examples test contract vulncheck tidy-check actionlint check-version-selftest apidiff apidiff-selftest coverage
 
 # The toolchain twin of the spec-drift watch: fails when go.dev lists a
 # newer stable Go than the newest one pinned in the workflows, so the

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ func main() {
 ```
 
 > [!TIP]
-> The [package examples](https://pkg.go.dev/pkg.venceslau.dev/ynab#pkg-examples)
-> are the fastest tour: 26 runnable programs covering every service — the full
-> delta-sync loop, split transactions, tri-state PATCH writes, both test seams.
+> Two flavors of examples: the [`examples/`](examples) directory holds runnable
+> programs that hit the real API (quickstart, delta-sync, splits, mock testing),
+> and the [package examples](https://pkg.go.dev/pkg.venceslau.dev/ynab#pkg-examples)
+> on pkg.go.dev cover every service offline — 26 runnable, `httptest`-backed.
 
 ## The plan handle
 

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ import (
 
 // Version is this library's release version, as sent in the
 // User-Agent header.
-const Version = "1.6.0"
+const Version = "1.6.1"
 
 // defaultBaseURL is the documented YNAB API root.
 const defaultBaseURL = "https://api.ynab.com/v1"

--- a/example_test.go
+++ b/example_test.go
@@ -19,7 +19,9 @@ import (
 // Example is the flagship vignette: construct a client, take the plan
 // handle, and read through it.
 func Example() {
-	// The httptest server stands in for api.ynab.com.
+	// The httptest server stands in for api.ynab.com so this runs offline
+	// and verifiably. For real programs against your own YNAB, see the
+	// examples/ directory in the repository.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"accounts":[
 			{"name":"Checking","balance_formatted":"$123.93"},

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# Examples
+
+Runnable programs — most call the **real** YNAB API — unlike the godoc
+[package examples](https://pkg.go.dev/pkg.venceslau.dev/ynab#pkg-examples)
+(which use `httptest` so they run offline and prove behavior). Copy one,
+export a token, and go.
+
+| Program | What it shows | Needs |
+|---|---|---|
+| [`quickstart`](quickstart) | List your accounts | `YNAB_TOKEN` |
+| [`delta-sync`](delta-sync) | Keep a local store in sync with delta reads | `YNAB_TOKEN` |
+| [`split-transaction`](split-transaction) | Create a split via `SplitEven` (writes!) | `YNAB_TOKEN`, `YNAB_PLAN_ID`, `YNAB_ACCOUNT_ID` |
+| [`testing-with-mock`](testing-with-mock) | Point the client at your own server for tests | — (offline) |
+
+```sh
+YNAB_TOKEN=your-personal-access-token go run ./examples/quickstart
+```
+
+Get a Personal Access Token at app.ynab.com → Settings → Developer
+Settings. The write example creates and leaves a real transaction —
+point it at a scratch plan.

--- a/examples/delta-sync/README.md
+++ b/examples/delta-sync/README.md
@@ -1,0 +1,10 @@
+# delta-sync
+
+Keeps a local transaction store in sync using delta reads, persisting the
+cursor between runs. Shows why the `store` and `SyncState` matter: after
+the first full read, each pass fetches only what changed (tombstones
+included).
+
+```sh
+YNAB_TOKEN=... go run ./examples/delta-sync
+```

--- a/examples/delta-sync/main.go
+++ b/examples/delta-sync/main.go
@@ -1,0 +1,104 @@
+// Command delta-sync keeps a local transaction store in sync with a plan
+// using delta reads, printing what changed on each pass.
+//
+//	YNAB_TOKEN=... go run ./examples/delta-sync
+//
+// The point of delta sync: after the first full read, each pass fetches
+// only what changed since the stored cursor — new/edited rows, plus
+// tombstones for deletions — so a polling integration stays well inside
+// YNAB's ~200 requests/hour quota. Persist the SyncState (it is plain
+// JSON) and the next process resumes exactly where this one left off.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"time"
+
+	"pkg.venceslau.dev/ynab"
+)
+
+// statePath holds only cursors and a concrete plan id — no credentials —
+// so it is safe to keep in the working directory (and to gitignore).
+const statePath = "synced-state.json"
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("delta sync", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// A long-running poller shuts down cleanly on Ctrl-C.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	client := ynab.New(os.Getenv("YNAB_TOKEN"))
+
+	// Persisted sync state MUST key to a concrete plan id, never the
+	// last-used/default alias: a stored cursor is only valid for the plan
+	// it came from, and the alias would hide a plan switch from Delta's
+	// guard, silently corrupting the store. So resolve a real id first.
+	plans, err := client.Plans(ctx)
+	if err != nil {
+		return err
+	}
+	if len(plans.Plans) == 0 {
+		return errors.New("no plans reachable by this token")
+	}
+	plan := client.Plan(ynab.PlanID(plans.Plans[0].ID))
+
+	// The store is your local cache: id -> transaction, carried across
+	// passes. MergeByID upserts changed rows and drops tombstoned ones.
+	store := map[string]ynab.TransactionBase{}
+	st := loadState() // resume the cursor from disk if a prior run saved one
+
+	for pass := 1; ; pass++ {
+		detail, err := plan.Delta(ctx, st)
+		if err != nil {
+			return err
+		}
+		before := len(store)
+		store = ynab.MergeByID(store, detail.Transactions)
+		fmt.Printf("pass %d: %d changed rows, store now holds %d (was %d)\n",
+			pass, len(detail.Transactions), len(store), before)
+
+		if err := saveState(st); err != nil { // persist the advanced cursor
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			fmt.Println("shutting down; cursor saved")
+			return nil
+		case <-time.After(30 * time.Second):
+		}
+	}
+}
+
+func loadState() *ynab.SyncState {
+	st := &ynab.SyncState{}
+	if raw, err := os.ReadFile(statePath); err == nil {
+		_ = json.Unmarshal(raw, st)
+	}
+	return st
+}
+
+// saveState writes the cursor atomically: a crash mid-write must not
+// truncate the file to a partial cursor.
+func saveState(st *ynab.SyncState) error {
+	raw, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	tmp := statePath + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, statePath)
+}

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,7 @@
+# quickstart
+
+Lists the accounts of your last-used plan.
+
+```sh
+YNAB_TOKEN=... go run ./examples/quickstart
+```

--- a/examples/quickstart/main.go
+++ b/examples/quickstart/main.go
@@ -1,0 +1,29 @@
+// Command quickstart lists the accounts of your last-used plan.
+//
+//	YNAB_TOKEN=... go run ./examples/quickstart
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"pkg.venceslau.dev/ynab"
+)
+
+func main() {
+	client := ynab.New(os.Getenv("YNAB_TOKEN"))
+	plan := client.Plan(ynab.PlanIDLastUsed) // resolves server-side; no id to look up
+
+	accounts, _, err := plan.Accounts.List(context.Background())
+	if err != nil {
+		slog.Error("listing accounts", "err", err)
+		os.Exit(1)
+	}
+	for _, a := range accounts {
+		// BalanceFormatted is the server's rendering; Balance is the exact
+		// int64 you do math on.
+		fmt.Printf("%-28s %14s\n", a.Name, a.BalanceFormatted)
+	}
+}

--- a/examples/split-transaction/README.md
+++ b/examples/split-transaction/README.md
@@ -1,0 +1,8 @@
+# split-transaction
+
+Creates a split transaction whose legs sum exactly to the parent via
+`SplitEven`. **Writes** — use a scratch plan.
+
+```sh
+YNAB_TOKEN=... YNAB_PLAN_ID=... YNAB_ACCOUNT_ID=... go run ./examples/split-transaction
+```

--- a/examples/split-transaction/main.go
+++ b/examples/split-transaction/main.go
@@ -1,0 +1,59 @@
+// Command split-transaction creates a split transaction whose legs sum
+// exactly to the parent, using SplitEven to divide the amount without
+// losing a milliunit to rounding.
+//
+// This WRITES a real transaction — point it at a scratch plan, never a
+// budget you rely on.
+//
+//	YNAB_TOKEN=... YNAB_PLAN_ID=... YNAB_ACCOUNT_ID=... go run ./examples/split-transaction
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"pkg.venceslau.dev/ynab"
+)
+
+func main() {
+	planID := os.Getenv("YNAB_PLAN_ID")
+	accountID := os.Getenv("YNAB_ACCOUNT_ID")
+	if planID == "" || accountID == "" {
+		// The target is explicit on purpose: this writes to a real budget,
+		// so you name the scratch plan rather than defaulting to last-used.
+		slog.Error("set YNAB_PLAN_ID (a scratch plan!) and YNAB_ACCOUNT_ID — this writes a real transaction")
+		os.Exit(1)
+	}
+	plan := ynab.New(os.Getenv("YNAB_TOKEN")).Plan(ynab.PlanID(planID))
+
+	// Split -100.00 three ways: SplitEven distributes the odd remainder so
+	// the legs sum to the parent exactly (-33.34, -33.33, -33.33).
+	total := ynab.UnitsToMilliunits(-100)
+	legs := total.SplitEven(3)
+
+	spec := ynab.TransactionSpec{
+		AccountID:  accountID,
+		Date:       ynab.Today(),
+		Amount:     total,
+		CategoryID: ynab.SetNull[string](), // a split parent carries no category
+		PayeeName:  ynab.Set("Example Store"),
+	}
+	for i, leg := range legs {
+		spec.Splits = append(spec.Splits, ynab.SubtransactionSpec{
+			Amount: leg,
+			Memo:   ynab.Set(fmt.Sprintf("leg %d", i+1)),
+		})
+	}
+
+	tx, _, err := plan.Transactions.Create(context.Background(), spec)
+	if err != nil {
+		slog.Error("creating split", "err", err)
+		os.Exit(1)
+	}
+	fmt.Printf("created split %s (%s) with %d legs:\n", tx.ID, tx.AmountFormatted, len(tx.Subtransactions))
+	for _, leg := range tx.Subtransactions {
+		fmt.Printf("  %s\n", leg.AmountFormatted)
+	}
+}

--- a/examples/testing-with-mock/README.md
+++ b/examples/testing-with-mock/README.md
@@ -1,0 +1,8 @@
+# testing-with-mock
+
+Points the client at an `httptest` server via `WithBaseURL` — no token,
+no network, deterministic. The seam for testing your own integration.
+
+```sh
+go run ./examples/testing-with-mock
+```

--- a/examples/testing-with-mock/main.go
+++ b/examples/testing-with-mock/main.go
@@ -1,0 +1,49 @@
+// Command testing-with-mock shows how to point the client at your own
+// server for tests — no token, no network, deterministic. This is the
+// one place httptest belongs: the subject IS testing. WithBaseURL is the
+// same seam the library's own examples use.
+//
+//	go run ./examples/testing-with-mock
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"pkg.venceslau.dev/ynab"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("mock example", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// Stand in for api.ynab.com: serve a canned accounts response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"data":{"accounts":[
+			{"name":"Checking","balance":128422,"balance_formatted":"$128.42"},
+			{"name":"Savings","balance":900000,"balance_formatted":"$900.00"}
+		],"server_knowledge":42}}`)
+	}))
+	defer srv.Close()
+
+	// WithBaseURL redirects every request to the fake; the token is unused.
+	client := ynab.New("test-token", ynab.WithBaseURL(srv.URL))
+
+	accounts, sk, err := client.Plan("plan-id").Accounts.List(context.Background())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("server_knowledge=%d\n", sk)
+	for _, a := range accounts {
+		fmt.Printf("%-10s %s (%d milliunits)\n", a.Name, a.BalanceFormatted, a.Balance)
+	}
+	return nil
+}

--- a/examples/testing-with-mock/main_test.go
+++ b/examples/testing-with-mock/main_test.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Bruno Venceslau. All rights reserved.
+// Use of this source code is governed by a BSD-2-Clause
+// license that can be found in the LICENSE file.
+
+package main
+
+// The mock example is fully offline and deterministic, so unlike the
+// live examples it can be executed and verified — its output is pinned.
+
+func Example_run() {
+	if err := run(); err != nil {
+		panic(err)
+	}
+	// Output:
+	// server_knowledge=42
+	// Checking   $128.42 (128422 milliunits)
+	// Savings    $900.00 (900000 milliunits)
+}

--- a/scripts/apidiff-selftest.sh
+++ b/scripts/apidiff-selftest.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# apidiff-selftest.sh — the network-free proof that apidiff.sh classifies
+# gorelease output correctly. It is the twin of check-version-selftest: a
+# handful of positive cases and "expected failures failed" negatives.
+#
+# The gate takes the gorelease command as argv, so we inject a *fake* gorelease
+# that prints canned output and returns a chosen exit code — the whole
+# classifier runs offline, with no real gorelease and no crafted API break.
+# A throwaway git repo carrying a v1.6.0 tag stands in for the module family,
+# so the run is hermetic against the real checkout's tags.
+set -euo pipefail
+
+here=$(cd "$(dirname "$0")" && pwd)
+gate="$here/apidiff.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fake="$tmp/fake-gorelease.sh"
+cat >"$fake" <<'STUB'
+#!/usr/bin/env bash
+# Ignores its args (the gate appends -base=...); prints a fixture, exits a code.
+cat "$FAKE_OUT"
+exit "${FAKE_RC:-1}"
+STUB
+chmod +x "$fake"
+
+repo="$tmp/repo"
+mkdir "$repo"
+git -C "$repo" init -q
+git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+# -c tag.*=false: a host may globally force signed/annotated tags; this
+# throwaway base tag needs neither.
+git -C "$repo" -c tag.gpgSign=false -c tag.forceSignAnnotated=false tag v1.6.0
+
+fixture() { printf '%s\n' "$2" >"$tmp/$1"; }
+
+# Exit code of the real gate when fed fixture $1 with fake exit code $2.
+run() (
+	cd "$repo"
+	FAKE_OUT="$tmp/$1" FAKE_RC="$2" "$gate" "$fake" >/dev/null 2>&1
+	echo $?
+)
+
+fail=0
+pass_case() { # fixture rc label
+	got=$(run "$1" "$2")
+	if [ "$got" != 0 ]; then
+		echo "FAIL: $3 — gate should PASS but exited $got"
+		fail=1
+	else
+		echo "ok (pass): $3"
+	fi
+}
+fail_case() { # fixture rc label
+	got=$(run "$1" "$2")
+	if [ "$got" = 0 ]; then
+		echo "FAIL: $3 — gate should FAIL but passed a break"
+		fail=1
+	else
+		echo "ok (fail): $3"
+	fi
+}
+
+fixture only_version '# pkg.venceslau.dev/ynab
+## incompatible changes
+Version: value changed from "1.6.0" to "1.6.1"
+
+# summary
+Incompatible changes were detected.'
+
+fixture version_plus_break '# pkg.venceslau.dev/ynab
+## incompatible changes
+Version: value changed from "1.6.0" to "1.6.1"
+WithTimeout: changed from func(time.Duration) Option to func(time.Duration, int) Option
+
+# summary'
+
+fixture break_only '# pkg.venceslau.dev/ynab
+## incompatible changes
+Client.RawDo: removed
+
+# summary'
+
+fixture version_removed '# pkg.venceslau.dev/ynab
+## incompatible changes
+Version: removed
+
+# summary'
+
+fixture version_const_to_var '# pkg.venceslau.dev/ynab
+## incompatible changes
+Version: changed from const to var
+
+# summary'
+
+fixture version_like_name '# pkg.venceslau.dev/ynab
+## incompatible changes
+VersionInfo: removed
+
+# summary'
+
+fixture cross_package '# pkg.venceslau.dev/ynab
+## incompatible changes
+Version: value changed from "1.6.0" to "1.6.1"
+
+# pkg.venceslau.dev/ynab/internal/transport
+## incompatible changes
+Core.Do: removed
+
+# summary'
+
+fixture clean '# pkg.venceslau.dev/ynab/examples/quickstart
+## compatible changes
+package added
+
+# summary
+Suggested version: v1.6.1'
+
+fixture crash 'gorelease: internal error resolving base'
+
+# Positives: the surface is compatible.
+pass_case only_version 1 'only a Version value bump is exempt'
+pass_case clean 0 'compatible-only diff (gorelease exit 0)'
+
+# Negatives: a real break must fail the gate.
+fail_case version_plus_break 1 'Version bump + a real break behind it'
+fail_case break_only 1 'a break with no Version line'
+fail_case version_removed 1 'Version removed is NOT a value bump'
+fail_case version_const_to_var 1 'Version const->var is NOT a value bump'
+fail_case version_like_name 1 'VersionInfo is not the Version symbol'
+fail_case cross_package 1 'a break in a second package still fails'
+fail_case crash 2 'gorelease crash fails closed'
+
+# The gate must reject an empty invocation rather than silently pass.
+got=$( (cd "$repo" && "$gate" >/dev/null 2>&1; echo $?) )
+if [ "$got" != 2 ]; then
+	echo "FAIL: missing gorelease command should exit 2, got $got"
+	fail=1
+else
+	echo 'ok (fail): missing gorelease command exits 2'
+fi
+
+if [ "$fail" -ne 0 ]; then
+	echo 'apidiff-selftest: FAILED'
+	exit 1
+fi
+echo 'ok: apidiff gate classifies every case correctly'

--- a/scripts/apidiff.sh
+++ b/scripts/apidiff.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# apidiff.sh — the public-surface compatibility gate.
+#
+# gorelease (golang.org/x/exp; its engine is x/exp/apidiff) diffs our
+# exported API against the latest release of THIS module's family (v1.6.0
+# and up — v0.1.0 still exists upstream under the archived predecessor's
+# module path, so an implicit base would produce a garbage cross-module
+# diff). Before the first family release there is no base: the gate says so
+# and passes.
+#
+# One change is deliberately exempt: a *value* bump of the exported `Version`
+# constant. Its value changes on every single release by construction, and
+# apidiff — correctly, by its own rules — treats a changed constant value as
+# an incompatible change (a const's value is usable in constant expressions,
+# so it is part of the API). But the version string is release metadata, not
+# a compatibility-bearing part of the surface: a value bump of `Version` alone
+# must never gate a release. Note the exemption is on the value-change message
+# only — removing `Version`, or changing its kind (const→var/func) or type,
+# keeps its own distinct apidiff message and still fails the gate, as does
+# every other incompatible change. So a real break cannot ride the exemption.
+#
+# Usage: apidiff.sh <gorelease-command...>
+#   e.g. CGO_ENABLED=0 apidiff.sh go run golang.org/x/exp/cmd/gorelease@vX
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+	echo 'apidiff.sh: missing gorelease command' >&2
+	exit 2
+fi
+
+# Prereleases (tags containing '-', e.g. v1.7.0-rc1) are never a compat base:
+# sort -V orders them adjacent to the final tag and they are not shipped API.
+# The `|| true` keeps the pipeline from tripping `set -e` when grep finds none.
+base=$(git tag -l 'v1.[6-9]*' 'v1.[1-9][0-9]*' 'v[2-9]*' |
+	{ grep -v -- '-' || true; } | sort -V | tail -1)
+if [ -z "$base" ]; then
+	echo 'apidiff: no released tag in this module family yet — activates after v1.6.0'
+	exit 0
+fi
+
+# Run gorelease, capturing output and exit code without tripping `set -e`.
+set +e
+out=$("$@" -base="$base" 2>&1)
+rc=$?
+set -e
+printf '%s\n' "$out"
+
+if [ "$rc" -eq 0 ]; then
+	exit 0
+fi
+
+# The gate failed. Collect every line that describes an incompatible change —
+# the body lines under each package's "## incompatible changes" heading.
+# (A heading or a new "# package" line ends the section; blank lines are
+# dropped by `NF`.)
+incompat=$(printf '%s\n' "$out" |
+	awk '/^## incompatible changes/{f=1;next} /^#/{f=0} f && NF')
+
+# Exactly one message is exempt: a value bump of the top-level Version const,
+# `Version: value changed from ...`. The exemption relies on Version living in
+# the root package — its message carries no "./pkg." path prefix; if it ever
+# moves to a subpackage this stops matching and the gate reverts to failing on
+# every release, loudly. Removal / kind-change / retype of Version keep their
+# own messages and are NOT exempt.
+#
+# If there is at least one incompatible change and every one is that exempt
+# value bump, the surface is compatible in every way that matters. Otherwise a
+# real break slipped in — fail with gorelease's own exit code.
+exempt='^Version: value changed from '
+nonexempt=$(printf '%s\n' "$incompat" | grep -v "$exempt" || true)
+if [ -n "$incompat" ] && [ -z "$nonexempt" ]; then
+	echo
+	echo 'apidiff: the only incompatible change is a Version value bump (release'
+	echo '         metadata, exempt by policy) — the public surface is compatible:'
+	printf '%s\n' "$incompat" | grep "$exempt" | sed 's/^/           /' || true
+	exit 0
+fi
+exit "$rc"


### PR DESCRIPTION
Adds an `examples/` directory with **runnable programs that hit the real YNAB API** — the gap the godoc examples (which use `httptest` so they run offline and prove behavior) don't fill. This is v1.6.1: docs/examples only, **zero API change** (the `apidiff` gate confirms it).

## What's here

| Program | Shows | Needs |
|---|---|---|
| `quickstart` | List your accounts | `YNAB_TOKEN` |
| `delta-sync` | A persisted-cursor sync loop | `YNAB_TOKEN` |
| `split-transaction` | A split via `SplitEven` (**writes**) | `YNAB_TOKEN`, `YNAB_PLAN_ID` (scratch!), `YNAB_ACCOUNT_ID` |
| `testing-with-mock` | The `WithBaseURL` seam (offline) | — |

Each has a short README; the top-level `examples/README.md` indexes them and flags the destructive one and the offline one.

## Shaped by a three-persona ship review

- **`delta-sync` bound its persisted cursor to `PlanIDLastUsed`** — exactly the footgun `Plan.Delta`'s own doc warns against: the alias hides a server-side plan switch from the guard, and `MergeByID` would silently corrupt the store. It now resolves a concrete plan id first, modeling the pattern persisted sync actually requires.
- **The write example** now demands an explicit scratch `YNAB_PLAN_ID` instead of defaulting to the live budget, with the warning carried into the source so it survives copy-paste.
- **`testing-with-mock` is an executed, output-pinned `Example`** — at least one example is verified *correct*, not merely compiled.
- **`make coverage` excludes `examples/`** from `-coverpkg` — without that, the four `main` packages diluted the tracked number from 97% to 91.7%. `make examples` (and CI) still builds them to catch signature drift.

## Gates

`make local-ci` green: lint (0 issues), test, contract, coverage **97.1%**, examples build, actionlint, tidy, check-version selftest. `signal.NotifyContext` for clean shutdown and an atomic cursor write round out `delta-sync`.